### PR TITLE
Pull default repo and user based on remote url, not just the first github repo in git-config

### DIFF
--- a/lib/ghi/cli.rb
+++ b/lib/ghi/cli.rb
@@ -232,10 +232,13 @@ module GHI::CLI #:nodoc:
     def parse!(*argv)
       @args, @argv = argv, argv.dup
 
-      remotes = `git config --get-regexp remote\..+\.url`.split /\n/
+      local_branch = `git name-rev --name-only HEAD`.strip
+      tracking_remote = `git config branch.#{local_branch}.remote`.strip
+      remote_url = `git config remote.#{tracking_remote}.url`.strip
       repo_expression = %r{([^:/]+)/([^/\s]+?)(?:\.git)?$}
-      if remote = remotes.find { |r| r.include? "github.com" }
-        remote.match repo_expression
+
+      if remote_url.include? "github.com"
+        remote_url.match repo_expression
         @user, @repo = $1, $2
       end
 


### PR DESCRIPTION
Currently ghi uses the first listed github.com remote url to work out the default user and repo.

If you have multiple github repos (eg. you're forking someone's github repo), then you may want to view the issues based on the current branch's remote url. 

For example, in our organisation we may have issues on the multiple branches or forks of a repo.
