### PR TITLE
If no command name is specified, default to list.

### DIFF
--- a/lib/ghi.rb
+++ b/lib/ghi.rb
@@ -59,7 +59,11 @@ EOF
         abort option_parser.banner
       end
 
-      if command_name.nil? || command_name == 'help'
+      if command_name.nil?
+        command_name = "list"
+      end
+
+      if command_name == 'help'
         Commands::Help.execute command_args, option_parser.banner
       else
         command_name = fetch_alias command_name, command_args


### PR DESCRIPTION
I keep typing `ghi` and it's annoying that it just prints the helper prompt. And I'm not alone!

It's more useful to print the listing than the help screen if a command name is excluded, so I added the default of `list`!
