### PR TITLE
Fix NoMethodError after editing an issue

### DIFF
--- a/ghi
+++ b/ghi
@@ -2958,17 +2958,17 @@ EOF
               e = Editor.new "GHI_ISSUE_#{issue}"
               message = e.gets format_editor(i)
               e.unlink "There's no issue." if message.nil? || message.empty?
-              assigns[:title], assigns[:body] = message.split(/\n+/, 2)
+              assigns['title'], assigns['body'] = message.split(/\n+/, 2)
             end
-            if i && assigns.keys.sort == [:body, :title]
-              titles_match = assigns[:title].strip == i['title'].strip
-              if assigns[:body]
-                bodies_match = assigns[:body].to_s.strip == i['body'].to_s.strip
+            if i && assigns.keys.sort == ['body', 'title']
+              titles_match = assigns['title'].strip == i['title'].strip
+              if assigns['body']
+                bodies_match = assigns['body'].to_s.strip == i['body'].to_s.strip
               end
               if titles_match && bodies_match
                 e.unlink if e
                 abort 'No change.' if assigns.dup.delete_if { |k, v|
-                  [:title, :body].include? k
+                  ['title', 'body'].include? k
                 }
               end
             end


### PR DESCRIPTION
The assigns.keys.sort call was raising the following error:

```
in `sort': undefined method `<=>' for :body:Symbol (NoMethodError)
```

This was on Ubuntu with `ruby --version`:

```
ruby 1.8.7 (2011-06-30 patchlevel 352) [i686-linux]
```
