### PR TITLE
Fix broken screenshot image URL in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,7 +38,7 @@ See 'ghi help <command>' for more information on a specific command.
 
 ## Screenshot
 
-![Example](/stephencelis/ghi/raw/master/images/example.png)
+![Example](https://github.com/stephencelis/ghi/raw/master/images/example.png)
 
 
 


### PR DESCRIPTION
I've simply prepended "https://github.com" to the Screenshot image URL in the README file to correctly display in github's preview.
