### PR TITLE
Recommend installation through RubyGems program

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,13 @@ Note: This is being rapidly prototyped for GitHub API v3.
 
 ## Install
 
+### Using RubyGems (recommended)
 
+``` bash
+$ gem install ghi
+```
+
+### Manually
 
 ``` bash
 $ curl -s https://raw.github.com/stephencelis/ghi/master/ghi > ghi && \


### PR DESCRIPTION
Installing through RubyGems program (`gem`) is much simpler and more robust.
