### PR TITLE
Make the separator separate from the number

### DIFF
--- a/lib/ghi/formatting.rb
+++ b/lib/ghi/formatting.rb
@@ -170,7 +170,8 @@ module GHI
         [
           " ",
           (i['repo'].to_s.rjust(rmax) if i['repo']),
-          "#{bright { n.to_s.rjust nmax }}:",
+          "#{bright { n.to_s.rjust nmax }}",
+          ":",
           truncate(title, l),
           format_labels(labels),
           (fg('aaaaaa') { c } unless c == 0),


### PR DESCRIPTION
Having the separator as part of the number is annoying when you want to use the number in any bash programming. Currently the way to do this is:

```
ghi | grep Sponsorship | awk '{gsub(/:/, "", $1); print $1}'
```

With this fix it's `ghi | grep Sponsorship | awk '{print $1}'`

just that little bit friendlier for reusing.
