### PR TITLE
Closes #87 Github Enterprise support.

### DIFF
--- a/lib/ghi/client.rb
+++ b/lib/ghi/client.rb
@@ -59,7 +59,8 @@ module GHI
       :patch  => Net::HTTP::Patch,
       :delete => Net::HTTP::Delete
     }
-    HOST = 'api.github.com'
+    DEFAULT_HOST = 'api.github.com'
+    HOST = GHI.config('github.host') || DEFAULT_HOST
     PORT = 443
 
     attr_reader :username, :password
@@ -94,6 +95,8 @@ module GHI
     private
 
     def request method, path, options
+      path = "/api/v3#{path}" if HOST != DEFAULT_HOST
+
       if params = options[:params] and !params.empty?
         q = params.map { |k, v| "#{CGI.escape k.to_s}=#{CGI.escape v.to_s}" }
         path += "?#{q.join '&'}"

--- a/lib/ghi/commands/command.rb
+++ b/lib/ghi/commands/command.rb
@@ -72,7 +72,8 @@ module GHI
       def remotes
         return @remotes if defined? @remotes
         @remotes = `git config --get-regexp remote\..+\.url`.split "\n"
-        @remotes.reject! { |r| !r.include? 'github.com'}
+        github_host = GHI.config('github.host') || 'github.com'
+        @remotes.reject! { |r| !r.include? github_host}
         @remotes.map! { |r|
           remote, user, repo = r.scan(
             %r{remote\.([^\.]+)\.url .*?([^:/]+)/([^/\s]+?)(?:\.git)?$}

--- a/lib/ghi/web.rb
+++ b/lib/ghi/web.rb
@@ -3,7 +3,8 @@ require 'uri'
 
 module GHI
   class Web
-    BASE_URI = 'https://github.com/'
+    HOST = GHI.config('github.host') || 'github.com'
+    BASE_URI = "https://#{HOST}/"
 
     attr_reader :base
     def initialize base


### PR DESCRIPTION
Read api endpoint via `github.host` config setting. Tested with latest Github Enterprise.
