### PR TITLE
ghi show -w doesn't work in linux

### DIFF
--- a/lib/ghi/web.rb
+++ b/lib/ghi/web.rb
@@ -12,7 +12,9 @@ module GHI
     end
 
     def open path = '', params = {}
-      system "open '#{uri_for path, params}'"
+      launcher = 'open'
+      launcher = 'xdg-open' if /linux/ =~ RUBY_PLATFORM
+      system "#{launcher} '#{uri_for path, params}'"
     end
 
     def curl path = '', params = {}


### PR DESCRIPTION
```
$ ghi show 100 -w
Couldn't get a file descriptor referring to the console
```

it's because of the command `open`
https://github.com/stephencelis/ghi/blob/master/lib/ghi/web.rb#L15
