### PR TITLE
ghi list -all now really lists all issues

### DIFF
--- a/lib/ghi/commands/list.rb
+++ b/lib/ghi/commands/list.rb
@@ -13,6 +13,7 @@ module GHI
           opts.banner = 'usage: ghi list [options]'
           opts.separator ''
           opts.on '-a', '--global', '--all', 'all of your issues on GitHub' do
+          	assigns[:filter] = 'all'
             @repo = nil
           end
           opts.on(

--- a/lib/ghi/formatting.rb
+++ b/lib/ghi/formatting.rb
@@ -136,6 +136,7 @@ module GHI
           when 'created'    then ' you created'
           when 'mentioned'  then ' that mention you'
           when 'subscribed' then " you're subscribed to"
+          when 'all'        then ' that you can see'
         else
           ' assigned to you'
         end


### PR DESCRIPTION
Currently `ghi list -all` lists only the issues assigned to the users. As far as I could find out there is no possibility to list all issues for a user. This pull request changes the behaviour of `ghi list -all` such that all issues are shown by default. Using the `--filter` option this output can still be filtered to only show the assigned issues.
