### PR TITLE
Added --no-truncate option to ghi list

### DIFF
--- a/lib/ghi/commands/list.rb
+++ b/lib/ghi/commands/list.rb
@@ -93,9 +93,6 @@ module GHI
           ) do |mentioned|
             assigns[:mentioned] = mentioned || Authorization.username
           end
-          opts.on '--no-truncate', 'do not truncate by terminal window size' do
-            assigns[:no_truncate] = true
-          end 
           opts.separator ''
         end
       end

--- a/lib/ghi/formatting.rb
+++ b/lib/ghi/formatting.rb
@@ -76,13 +76,10 @@ module GHI
     end
 
     def truncate string, reserved
-      if assigns[:no_truncate]
-        string
-      else
-        result = string.scan(/.{0,#{columns - reserved}}(?:\s|\Z)/).first.strip
-        result << "..." if result != string
-        result
-      end
+      return string unless $stdout.tty?
+      result = string.scan(/.{0,#{columns - reserved}}(?:\s|\Z)/).first.strip
+      result << "..." if result != string
+      result
     end
 
     def indent string, level = 4, maxwidth = columns


### PR DESCRIPTION
This is a simple addition to disable truncating the output whit `ghi list --no-truncate`

Closes stephencelis/ghi#138
