### PR TITLE
Fixes minor bug in Colors#highlight

### DIFF
--- a/lib/ghi/formatting/colors.rb
+++ b/lib/ghi/formatting/colors.rb
@@ -38,6 +38,7 @@ module GHI
       end
 
       def highlight(code_block)
+        return code_block unless colorize?
         highlighter.highlight(code_block)
       end
 


### PR DESCRIPTION
Sorry for not seeing this sooner in #150.

Forgot to take `#colorize?` into account, when a `format` method is called in a `no_color` block (e.g. when editing an issue).
