### PR TITLE
Pass user to store_token, not username

### DIFF
--- a/lib/ghi/authorization.rb
+++ b/lib/ghi/authorization.rb
@@ -39,7 +39,7 @@ module GHI
           system "git config#{' --global' unless local} github.user #{user}"
         end
 
-        store_token! username, token, local
+        store_token! user, token, local
       rescue Client::Error => e
         if e.response['X-GitHub-OTP'] =~ /required/
           puts "Bad code." if code


### PR DESCRIPTION
I'm not sure if this is the right fix - I'm not totally clear on when username is called, but some change in this area so that a blank user name isn't passed to store_token seems needed. Part fixes #165.
