### PR TITLE
Don't highlight if code block doesn't have a defined language

### DIFF
--- a/lib/ghi/formatting/colors.rb
+++ b/lib/ghi/formatting/colors.rb
@@ -331,7 +331,11 @@ module GHI
             lang   = code_block['lang']
             code   = code_block['code']
 
-            output = pygmentize(lang, code)
+            if lang != ""
+              output = pygmentize(lang, code)
+            else
+              output = code
+            end
             with_indentation(output, indent)
           rescue
             code_block


### PR DESCRIPTION
I'm seeing weird colours in code blocks with no defined language.

```
diff --git a/lib/ghi/formatting/colors.rb b/lib/ghi/formatting/colors.rb
index bb2d077..dcfc976 100644
--- a/lib/ghi/formatting/colors.rb
+++ b/lib/ghi/formatting/colors.rb
@@ -331,7 +331,11 @@ module GHI
             lang   = code_block['lang']
             code   = code_block['code']

-            output = pygmentize(lang, code)
+            if lang != ""
+              output = pygmentize(lang, code)
+            else
+              output = code
+            end
             with_indentation(output, indent)
           rescue
             code_block
```
