### PR TITLE
Support for listing all (open & closed) issues #191

### DIFF
--- a/ghi
+++ b/ghi
@@ -1815,7 +1815,11 @@ module GHI
             lang   = code_block['lang']
             code   = code_block['code']
 
-            output = pygmentize(lang, code)
+            if lang != ""
+              output = pygmentize(lang, code)
+            else
+              output = code
+            end
             with_indentation(output, indent)
           rescue
             code_block
@@ -2354,6 +2358,7 @@ EOF
   end
 end
 # encoding: utf-8
+require 'socket'
 
 module GHI
   module Authorization
@@ -2394,7 +2399,7 @@ module GHI
           system "git config#{' --global' unless local} github.user #{user}"
         end
 
-        store_token! username, token, local
+        store_token! user, token, local
       rescue Client::Error => e
         if e.response['X-GitHub-OTP'] =~ /required/
           puts "Bad code." if code
@@ -3593,8 +3598,8 @@ module GHI
             @repo = nil
           end
           opts.on(
-            '-s', '--state <in>', %w(open closed),
-            {'o'=>'open', 'c'=>'closed'}, "'open' or 'closed'"
+            '-s', '--state <in>', %w(all open closed),
+            {'o'=>'open', 'c'=>'closed', 'a'=>'all'}, "'all', 'open' or 'closed'"
           ) do |state|
             assigns[:state] = state
           end
@@ -3728,7 +3733,15 @@ module GHI
             if verbose
               puts issues.map { |i| format_issue i }
             else
-              puts format_issues(issues, repo.nil?)
+              if assigns[:state] == 'all'
+                open,closed = issues.partition { |i| i['state'] == 'open' }
+                print format_state 'open', "\n# Open issues\n"
+                puts format_issues(open, repo.nil?)
+                print format_state 'closed', "\n# Closed issues\n"
+                puts format_issues(closed, repo.nil?)
+              else
+                puts format_issues(issues, repo.nil?)
+              end
             end
             break unless res.next_page
             res = throb { api.get res.next_page }
@@ -3753,6 +3766,7 @@ module GHI
       def fallback
         OptionParser.new do |opts|
           opts.on('-c', '--closed') { assigns[:state] = 'closed' }
+          opts.on('-a', '--all')    { assigns[:state] = 'all' }
           opts.on('-q', '--quiet')  { self.quiet = true }
         end
       end

--- a/lib/ghi/commands/list.rb
+++ b/lib/ghi/commands/list.rb
@@ -18,8 +18,8 @@ module GHI
             @repo = nil
           end
           opts.on(
-            '-s', '--state <in>', %w(open closed),
-            {'o'=>'open', 'c'=>'closed'}, "'open' or 'closed'"
+            '-s', '--state <in>', %w(all open closed),
+            {'o'=>'open', 'c'=>'closed', 'a'=>'all'}, "'all', 'open' or 'closed'"
           ) do |state|
             assigns[:state] = state
           end
@@ -153,7 +153,15 @@ module GHI
             if verbose
               puts issues.map { |i| format_issue i }
             else
-              puts format_issues(issues, repo.nil?)
+              if assigns[:state] == 'all'
+                open,closed = issues.partition { |i| i['state'] == 'open' }
+                print format_state 'open', "\n# Open issues\n"
+                puts format_issues(open, repo.nil?)
+                print format_state 'closed', "\n# Closed issues\n"
+                puts format_issues(closed, repo.nil?)
+              else
+                puts format_issues(issues, repo.nil?)
+              end
             end
             break unless res.next_page
             res = throb { api.get res.next_page }
@@ -178,6 +186,7 @@ module GHI
       def fallback
         OptionParser.new do |opts|
           opts.on('-c', '--closed') { assigns[:state] = 'closed' }
+          opts.on('-a', '--all')    { assigns[:state] = 'all' }
           opts.on('-q', '--quiet')  { self.quiet = true }
         end
       end


### PR DESCRIPTION
This supports the listing all of issues on a repo, by use of a `--state all` command line option. This doesn't color the output because I actually couldn't figure out how to use the `format_issues_header` method, as it seems to do some weird stuff with the output.

As such, this is a non-fancy add on that prints `# Open/Closed issue` before listing each group.

Example usage. `ghi list --state all`