### PR TITLE
Add missing colon when --no-color is specified

### DIFF
--- a/lib/ghi/formatting.rb
+++ b/lib/ghi/formatting.rb
@@ -198,7 +198,7 @@ module GHI
     end
 
     def format_number n
-      colorize? ? "#{bright { n }}:" : "#{n} "
+      colorize? ? "#{bright { n }}:" : "#{n}:"
     end
 
     # TODO: Show milestone, number of comments, pull request attached.


### PR DESCRIPTION
When I attempted to parse the output of `ghi` with `--no-color` option, I noticed that colon was missing.  This patch fixes it.

### e.g.
  - `ghi list -- rhysd/clever-f.vim` 

```
# rhysd/clever-f.vim open issues
17: no map memory on repeat ↑ @
8: Repeat like key pressed to repeat 3
6: More persistent repeating 2
```

  - `ghi --no-color list -- rhysd/clever-f.vim`

```
# rhysd/clever-f.vim open issues
  17  no map memory on repeat ↑ @
   8  Repeat like key pressed to repeat 3
   6  More persistent repeating 2
```
