### PR TITLE
Adds a -O option to the open command that writes the newly created issue id to a file

### DIFF
--- a/ghi
+++ b/ghi
@@ -1815,7 +1815,11 @@ module GHI
             lang   = code_block['lang']
             code   = code_block['code']
 
-            output = pygmentize(lang, code)
+            if lang != ""
+              output = pygmentize(lang, code)
+            else
+              output = code
+            end
             with_indentation(output, indent)
           rescue
             code_block
@@ -2354,6 +2358,7 @@ EOF
   end
 end
 # encoding: utf-8
+require 'socket'
 
 module GHI
   module Authorization
@@ -2394,7 +2399,7 @@ module GHI
           system "git config#{' --global' unless local} github.user #{user}"
         end
 
-        store_token! username, token, local
+        store_token! user, token, local
       rescue Client::Error => e
         if e.response['X-GitHub-OTP'] =~ /required/
           puts "Bad code." if code
@@ -4009,6 +4014,11 @@ EOF
           ) do |labels|
             (assigns[:labels] ||= []).concat labels
           end
+          opts.on(
+            '-O', '--outfile <filename>...', 'write formatted issue to filename, not stdout'
+          ) do |outfile|
+            self.outfile = outfile
+          end
           opts.separator ''
         end
       end
@@ -4048,7 +4058,8 @@ EOF
             end
             i = throb { api.post "/repos/#{repo}/issues", assigns }.body
             e.unlink if e
-            puts format_issue(i)
+            write_issue_id(i, self.outfile) if self.outfile
+            puts format_issue(i)            
             puts "Opened on #{repo}."
           end
         end

--- a/ghi
+++ b/ghi
@@ -3975,7 +3975,7 @@ module GHI
     class Open < Command
       attr_accessor :editor
       attr_accessor :web
-
+      attr_accessor :outfile
       def options
         OptionParser.new do |opts|
           opts.banner = <<EOF
@@ -4023,6 +4023,12 @@ EOF
         end
       end
 
+      def write_issue_id(issue)
+          open(self.outfile, 'w') { |f|
+            f.puts issue['number']
+          }
+      end
+
       def execute
         require_repo
         self.action = 'create'
@@ -4058,8 +4064,8 @@ EOF
             end
             i = throb { api.post "/repos/#{repo}/issues", assigns }.body
             e.unlink if e
-            write_issue_id(i, self.outfile) if self.outfile
-            puts format_issue(i)            
+            self.write_issue_id(i) if self.outfile
+            puts format_issue(i)
             puts "Opened on #{repo}."
           end
         end

--- a/lib/ghi/commands/open.rb
+++ b/lib/ghi/commands/open.rb
@@ -3,7 +3,7 @@ module GHI
     class Open < Command
       attr_accessor :editor
       attr_accessor :web
-
+      attr_accessor :outfile
       def options
         OptionParser.new do |opts|
           opts.banner = <<EOF
@@ -51,6 +51,12 @@ EOF
         end
       end
 
+      def write_issue_id(issue)
+          open(self.outfile, 'w') { |f|
+            f.puts issue['number']
+          }
+      end
+
       def execute
         require_repo
         self.action = 'create'
@@ -86,9 +92,8 @@ EOF
             end
             i = throb { api.post "/repos/#{repo}/issues", assigns }.body
             e.unlink if e
-            if self.outfile
-              write_issue_id(i, self.outfile)
-            puts format_issue(i)            
+            self.write_issue_id(i) if self.outfile
+            puts format_issue(i)
             puts "Opened on #{repo}."
           end
         end

--- a/lib/ghi/commands/open.rb
+++ b/lib/ghi/commands/open.rb
@@ -42,6 +42,11 @@ EOF
           ) do |labels|
             (assigns[:labels] ||= []).concat labels
           end
+          opts.on(
+            '-O', '--outfile <filename>...', 'write formatted issue to filename, not stdout'
+          ) do |outfile|
+            self.outfile = outfile
+          end
           opts.separator ''
         end
       end
@@ -81,7 +86,9 @@ EOF
             end
             i = throb { api.post "/repos/#{repo}/issues", assigns }.body
             e.unlink if e
-            puts format_issue(i)
+            if self.outfile
+              write_issue_id(i, self.outfile)
+            puts format_issue(i)            
             puts "Opened on #{repo}."
           end
         end


### PR DESCRIPTION
Adds a -O option to the open command that writes the newly created issue id to a file, e.g

ghi open -O $(mktemp) ...

I've been using ghi in workflows where I run ghi open as part of a script need to capture the newly created issue id in order to perform subsequent steps in the workflow. When using emacs as $EDITOR, I can pipe ghi open to tee and then parse the issue ID from stdout, but for other editors that don't manipulate the terminal directly, this isn't possible.

It probably makes more sense to get this value from the environment, since the feature is mostly useful for scripting, but I didn't 