### PR TITLE
Add config option to disable inferring issue

### DIFF
--- a/lib/ghi/commands/open.rb
+++ b/lib/ghi/commands/open.rb
@@ -52,7 +52,7 @@ EOF
 
         options.parse! args
 
-        if extract_issue
+        if GHI.config('ghi.infer-issue') != 'false' && extract_issue
           Edit.execute args.push('-so', issue, '--', repo)
           exit
         end


### PR DESCRIPTION
Add a config option `ghi.infer-issue` that, if set to "false", will
disable inferring the issue from the branch prefix

Fixes #198