### PR TITLE
Remove errant comment in `ghi comment`

### DIFF
--- a/ghi
+++ b/ghi
@@ -2245,9 +2245,9 @@ EOF
     def format_comment_editor issue, comment = nil
       message = ERB.new(<<EOF).result binding
 
-Leave a comment. The first line will become the title. Trailing lines starting
-with '#' (like these) will be ignored, and empty messages will not be
-submitted. Comments are formatted with GitHub Flavored Markdown (GFM):
+Leave a comment. Trailing lines starting with '#' (like these) will be 
+ignored, and empty messages will not be submitted. Comments are formatted 
+with GitHub Flavored Markdown (GFM):
 
   http://github.github.com/github-flavored-markdown
 

--- a/lib/ghi/formatting.rb
+++ b/lib/ghi/formatting.rb
@@ -403,9 +403,9 @@ EOF
     def format_comment_editor issue, comment = nil
       message = ERB.new(<<EOF).result binding
 
-Leave a comment. The first line will become the title. Trailing lines starting
-with '#' (like these) will be ignored, and empty messages will not be
-submitted. Comments are formatted with GitHub Flavored Markdown (GFM):
+Leave a comment. Trailing lines starting with '#' (like these) will be ignored, 
+and empty messages will not be submitted. Comments are formatted with GitHub 
+Flavored Markdown (GFM):
 
   http://github.github.com/github-flavored-markdown
 


### PR DESCRIPTION
When commenting, the first line does not become the title. This is erroneous
and misleading, although it does apply to `ghi open`, which is defined elsewhere.
I suspect this was a copy paste. This PR fixes this issue.