### PR TITLE
Navigate to the actual setting URL for Github Enterprise

### DIFF
--- a/lib/ghi/authorization.rb
+++ b/lib/ghi/authorization.rb
@@ -52,12 +52,13 @@ module GHI
         end
 
         if e.errors.any? { |err| err['code'] == 'already_exists' }
+          host = GHI.config('github.host') || 'github.com'
           message = <<EOF.chomp
 A ghi token already exists!
 
 Please revoke all previously-generated ghi personal access tokens here:
 
-  https://github.com/settings/applications
+  https://#{host}/settings/applications
 EOF
         else
           message = e.message


### PR DESCRIPTION
The original code showed github.com URL even though github.host is configured to another one.