### PR TITLE
Fix a bug in formatting.rb

### DIFF
--- a/lib/ghi/formatting.rb
+++ b/lib/ghi/formatting.rb
@@ -84,7 +84,9 @@ module GHI
 
     def truncate string, reserved
       return string unless paginate?
-      result = string.scan(/.{0,#{columns - reserved}}(?:\s|\Z)/).first.strip
+      space=columns - reserved
+      space=5 if space < 5
+      result = string.scan(/.{0,#{space}}(?:\s|\Z)/).first.strip
       result << "..." if result != string
       result
     end


### PR DESCRIPTION
This fixes a bug when in 'truncate' reserved is higher than 'columns'. This would launch an exception, so that 'ghi list' would returs an empty list