### PR TITLE
Change a message when a ghi token already exists

### DIFF
--- a/lib/ghi/authorization.rb
+++ b/lib/ghi/authorization.rb
@@ -58,7 +58,7 @@ A ghi token already exists!
 
 Please revoke all previously-generated ghi personal access tokens here:
 
-  https://#{host}/settings/applications
+  https://#{host}/settings/tokens
 EOF
         else
           message = e.message


### PR DESCRIPTION
Now a ghi token is stored in https://github.com/settings/tokens . (not in https://github.com/settings/applications)

![ghi](https://cloud.githubusercontent.com/assets/328893/12012951/867f3e9c-ad4e-11e5-8fdd-a3acc67aabe9.png)

refs: https://github.com/stephencelis/ghi/issues/189#issuecomment-138334785