### PR TITLE
Fix issues where unassign command fails.

### DIFF
--- a/ghi
+++ b/ghi
@@ -2426,7 +2426,7 @@ A ghi token already exists!
 
 Please revoke all previously-generated ghi personal access tokens here:
 
-  https://#{host}/settings/applications
+  https://#{host}/settings/tokens
 EOF
         else
           message = e.message
@@ -2646,9 +2646,9 @@ module GHI
         if password.nil?
           raise Authorization::Required, 'Authorization required'
         end
-			when Net::HTTPMovedPermanently
-				return Response.new(http.get(res['location']))
-			end
+      when Net::HTTPMovedPermanently
+        return Response.new(http.get(res['location']))
+      end
 
       raise Error, res
     end
@@ -2914,7 +2914,7 @@ EOF
           assigns[:assignee] = args.pop || Authorization.username
         end
         if assigns.key? :assignee
-          assigns[:assignee].sub! /^@/, ''
+          assigns[:assignee].sub! /^@/, '' if assigns[:assignee]
           assigns[:args].concat(
             assigns[:assignee] ? %W(-u #{assigns[:assignee]}) : %w(--no-assign)
           )
@@ -3226,7 +3226,7 @@ EOF
           opts.on(
             '-u', '--[no-]assign [<user>]', 'assign to specified user'
           ) do |assignee|
-            assigns[:assignee] = assignee
+            assigns[:assignee] = assignee || nil
           end
           opts.on '--claim', 'assign to yourself' do
             assigns[:assignee] = Authorization.username

--- a/lib/ghi/commands/assign.rb
+++ b/lib/ghi/commands/assign.rb
@@ -36,7 +36,7 @@ EOF
           assigns[:assignee] = args.pop || Authorization.username
         end
         if assigns.key? :assignee
-          assigns[:assignee].sub! /^@/, ''
+          assigns[:assignee].sub! /^@/, '' if assigns[:assignee]
           assigns[:args].concat(
             assigns[:assignee] ? %W(-u #{assigns[:assignee]}) : %w(--no-assign)
           )

--- a/lib/ghi/commands/edit.rb
+++ b/lib/ghi/commands/edit.rb
@@ -18,7 +18,7 @@ EOF
           opts.on(
             '-u', '--[no-]assign [<user>]', 'assign to specified user'
           ) do |assignee|
-            assigns[:assignee] = assignee
+            assigns[:assignee] = assignee || nil
           end
           opts.on '--claim', 'assign to yourself' do
             assigns[:assignee] = Authorization.username


### PR DESCRIPTION
#### This fixes an issue where `sub!` raises `NoMethodError`.

When you `unassign`, `assigns[:assignee].sub!` raises `NoMethodError` because `assigns[:assignee]` is `nil`.
So It needs to check for nil.

The error was like:
```
/Users/usp/bin/ghi:2917:in `execute': undefined method `sub!' for nil:NilClass (NoMethodError)
	from /Users/usp/bin/ghi:2762:in `execute'
	from /Users/usp/bin/ghi:91:in `execute'
	from /Users/usp/bin/ghi:4285:in `<main>'
```

#### This also fixes an issue where github rejects a request when ghi try to set `assignee` as `false`.

When you `unassign`, ghi sends `false` for `assignee` while github doesn't allow `false` for `assignee` but rather `null`.
So I assigned `nil` when `assignee` is `false`.

The error was like:
```
Invalid request.

For 'properties/assignee', false is not a string or null.
```

---

Thanks. :smile: :sushi: