### PR TITLE
Add --no-labels option to `ghi-list`

### DIFF
--- a/ghi
+++ b/ghi
@@ -733,7 +733,7 @@ module GHI
           (i['repo'].to_s.rjust(rmax) if i['repo']),
           format_number(n.to_s.rjust(nmax)),
           truncate(title, l),
-          format_labels(labels),
+          (format_labels(labels) unless assigns[:dont_print_labels]),
           (fg(:green) { m['title'] } if m),
           (fg('aaaaaa') { c } unless c == 0),
           (fg('aaaaaa') { '↑' } if p),
@@ -953,8 +953,8 @@ EOF
     def format_comment_editor issue, comment = nil
       message = ERB.new(<<EOF).result binding
 
-Leave a comment. Trailing lines starting with '#' (like these) will be ignored, 
-and empty messages will not be submitted. Comments are formatted with GitHub 
+Leave a comment. Trailing lines starting with '#' (like these) will be ignored,
+and empty messages will not be submitted. Comments are formatted with GitHub
 Flavored Markdown (GFM):
 
   http://github.github.com/github-flavored-markdown
@@ -2386,7 +2386,6 @@ module GHI
       attr_accessor :pull_requests_only
 
       def options
-
         OptionParser.new do |opts|
           opts.banner = 'usage: ghi list [options]'
           opts.separator ''
@@ -2409,6 +2408,11 @@ module GHI
             '-N', '--not-label <labelname>...', Array, 'exclude with label(s)'
           ) do |labels|
             (assigns[:exclude_labels] ||= []).concat labels
+          end
+          opts.on(
+            '--no-labels', 'do not print labels'
+          ) do
+            assigns[:dont_print_labels] = true
           end
           opts.on(
             '-S', '--sort <by>', %w(created updated comments),

--- a/lib/ghi/commands/list.rb
+++ b/lib/ghi/commands/list.rb
@@ -34,6 +34,11 @@ module GHI
             (assigns[:exclude_labels] ||= []).concat labels
           end
           opts.on(
+            '--no-labels', 'do not print labels'
+          ) do
+            assigns[:dont_print_labels] = true
+          end
+          opts.on(
             '-S', '--sort <by>', %w(created updated comments),
             {'c'=>'created','u'=>'updated','m'=>'comments'},
             "'created', 'updated', or 'comments'"

--- a/lib/ghi/formatting.rb
+++ b/lib/ghi/formatting.rb
@@ -193,7 +193,7 @@ module GHI
           (i['repo'].to_s.rjust(rmax) if i['repo']),
           format_number(n.to_s.rjust(nmax)),
           truncate(title, l),
-          format_labels(labels),
+          (format_labels(labels) unless assigns[:dont_print_labels]),
           (fg(:green) { m['title'] } if m),
           (fg('aaaaaa') { c } unless c == 0),
           (fg('aaaaaa') { '↑' } if p),
@@ -413,8 +413,8 @@ EOF
     def format_comment_editor issue, comment = nil
       message = ERB.new(<<EOF).result binding
 
-Leave a comment. Trailing lines starting with '#' (like these) will be ignored, 
-and empty messages will not be submitted. Comments are formatted with GitHub 
+Leave a comment. Trailing lines starting with '#' (like these) will be ignored,
+and empty messages will not be submitted. Comments are formatted with GitHub
 Flavored Markdown (GFM):
 
   http://github.github.com/github-flavored-markdown


### PR DESCRIPTION
There have been a few requests for an option to prevent printing labels
when listing issues. If the list of issues involves a lot of labels, it
leads to truncation of issue titles. To make it easier to visually parse
lists like this, I've added a `--no-labels` option to `ghi-list` to
skip printing labels in the pager. Closes #259.