### PR TITLE
Fix uncaught LoadError requiring pygments.rb

### DIFF
--- a/ghi
+++ b/ghi
@@ -487,7 +487,7 @@ module GHI
           raise unless supports_256_colors?
           require 'pygments'
           Pygmentizer.new
-        rescue
+        rescue StandardError, LoadError
           FakePygmentizer.new
         end
       end

--- a/lib/ghi/formatting/colors.rb
+++ b/lib/ghi/formatting/colors.rb
@@ -309,7 +309,7 @@ module GHI
           raise unless supports_256_colors?
           require 'pygments'
           Pygmentizer.new
-        rescue
+        rescue StandardError, LoadError
           FakePygmentizer.new
         end
       end


### PR DESCRIPTION
If `ghi` was installed via Homebrew before pygments.rb was added as a
dependency, the check for pygments being installed never gets run. It
looks like there was intention to rescue that `require` statement but
because `LoadError` doesn't inherit from `StandardError`, the exception
was uncaught and `ghi` would silently exit. This only seems to happen
currently on issues that include fenced code blocks, but I provided
reproducible evidence in #281. Merging this will fix #281, but I have
two concerns about the fact that pygments.rb was included as a
dependency in the first place:

1. Homebrew doesn't install Ruby gems for you, so this has to be done
   manually. Attempting to `brew install ghi` without first having run
   `gem install pygments.rb` just outputs an error and doesn't finish.
2. Most Ruby developers install several versions of Ruby using a version
   manager like rvm, rbenv, or chruby. You can `gem install pygments.rb`
   on one version of Ruby (or `sudo gem install pygments.rb` on the
   system version of Ruby, which is a whole other problem) but as soon
   as you try to use `ghi` after switching Rubies, you have to remember
   to install `pygments.rb`. This isn't great.

I see two solutions here. We can either no longer offer a Homebrew
formula, instead urging users to just install via `gem install ghi` or
we can remove pygments.rb as a dependency. Personally I think `ghi`
should try to remain free of dependencies for this reason, but I leave
it in your hands.