### PR TITLE
Add support for proxy authentication

### DIFF
--- a/ghi
+++ b/ghi
@@ -1324,7 +1324,7 @@ module GHI
       proxy ||= GHI.config 'http.proxy',  :upcase => false
       if proxy
         proxy = URI.parse proxy
-        http = Net::HTTP::Proxy(proxy.host, proxy.port).new HOST, PORT
+        http = Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).new HOST, PORT
       else
         http = Net::HTTP.new HOST, PORT
       end
@@ -1422,7 +1422,14 @@ module GHI
     end
 
     def curl path = '', params = {}
-      uri_for(path, params).open.read
+      proxy_uri   = GHI.config 'https.proxy', :upcase => false
+      proxy_uri ||= GHI.config 'http.proxy',  :upcase => false
+      proxy = URI.parse proxy_uri
+      if !(proxy.user.nil? || proxy.password.nil?)
+        uri_for(path, params).open(:proxy_http_basic_authentication => [proxy_uri, proxy.user, proxy.password]).read
+      else
+        uri_for(path, params).open.read
+      end
     end
 
     private

--- a/lib/ghi/client.rb
+++ b/lib/ghi/client.rb
@@ -119,7 +119,7 @@ module GHI
       proxy ||= GHI.config 'http.proxy',  :upcase => false
       if proxy
         proxy = URI.parse proxy
-        http = Net::HTTP::Proxy(proxy.host, proxy.port).new HOST, PORT
+        http = Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).new HOST, PORT
       else
         http = Net::HTTP.new HOST, PORT
       end

--- a/lib/ghi/web.rb
+++ b/lib/ghi/web.rb
@@ -21,7 +21,14 @@ module GHI
     end
 
     def curl path = '', params = {}
-      uri_for(path, params).open.read
+      proxy_uri   = GHI.config 'https.proxy', :upcase => false
+      proxy_uri ||= GHI.config 'http.proxy',  :upcase => false
+      proxy = URI.parse proxy_uri
+      if !(proxy.user.nil? || proxy.password.nil?)
+        uri_for(path, params).open(:proxy_http_basic_authentication => [proxy_uri, proxy.user, proxy.password]).read
+      else
+        uri_for(path, params).open.read
+      end
     end
 
     private


### PR DESCRIPTION
In lib/ghi/client.rb line 122 use 
`http = Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).new HOST, PORT`
instead of
`http = Net::HTTP::Proxy(proxy.host, proxy.port).new HOST, PORT`