### PR TITLE
Use application/vnd.github.v3+json

### DIFF
--- a/ghi
+++ b/ghi
@@ -1254,7 +1254,7 @@ module GHI
       end
     end
 
-    CONTENT_TYPE = 'application/vnd.github.beta+json'
+    CONTENT_TYPE = 'application/vnd.github.v3+json'
     USER_AGENT = 'ghi/%s (%s; +%s)' % [
       GHI::Commands::Version::VERSION,
       RUBY_DESCRIPTION,
@@ -2539,7 +2539,7 @@ module GHI
             issues = res.body
 
             if exclude_pull_requests || pull_requests_only
-              prs, issues = issues.partition { |i| i['pull_request'].values.any? }
+              prs, issues = issues.partition { |i| i.key?('pull_request') }
               issues = prs if pull_requests_only
             end
             if assigns[:exclude_labels]
@@ -2949,7 +2949,7 @@ module GHI
       private
 
       def pull_request?(issue)
-        issue['pull_request']['html_url']
+        issue.key?('pull_request')
       end
 
       def determine_merge_status(pr)

--- a/lib/ghi/client.rb
+++ b/lib/ghi/client.rb
@@ -45,7 +45,7 @@ module GHI
       end
     end
 
-    CONTENT_TYPE = 'application/vnd.github.beta+json'
+    CONTENT_TYPE = 'application/vnd.github.v3+json'
     USER_AGENT = 'ghi/%s (%s; +%s)' % [
       GHI::Commands::Version::VERSION,
       RUBY_DESCRIPTION,

--- a/lib/ghi/commands/list.rb
+++ b/lib/ghi/commands/list.rb
@@ -151,7 +151,7 @@ module GHI
             issues = res.body
 
             if exclude_pull_requests || pull_requests_only
-              prs, issues = issues.partition { |i| i['pull_request'].values.any? }
+              prs, issues = issues.partition { |i| i.key?('pull_request') }
               issues = prs if pull_requests_only
             end
             if assigns[:exclude_labels]

--- a/lib/ghi/commands/show.rb
+++ b/lib/ghi/commands/show.rb
@@ -49,7 +49,7 @@ module GHI
       private
 
       def pull_request?(issue)
-        issue['pull_request']['html_url']
+        issue.key?('pull_request')
       end
 
       def determine_merge_status(pr)


### PR DESCRIPTION
The `application/vnd.github.beta+json` media type has been
[deprecated](https://developer.github.com/v3/versions/) for quite some time. It's recommended that the actual API
version, v3, be used instead.

This had only a minor impact to GHI: in v3, the `"pull_request"` key of
an issue response is omitted for issues that are not also pull requests.
Previously, `"pull_request"` would still be present but empty.

Signed-off-by: David Celis <me@davidcel.is>