### PR TITLE
Add [ -- [<user>/]<repo> ] suffix to warning

### DIFF
--- a/ghi
+++ b/ghi
@@ -1510,8 +1510,13 @@ module GHI
 
       def require_repo
         return true if repo
-        warn 'Not a GitHub repo.'
-        warn ''
+        warn <<-WARNING
+Current directory is not a GitHub repository. Please retry this command from a
+directory that is also GitHub repository or by using the user/repo suffix:
+
+    #{$0} -- [<user>/]<repo>
+
+        WARNING
         abort options.to_s
       end
 
@@ -1525,7 +1530,7 @@ module GHI
         end
         return repo_name
       end
-        
+
       def detect_repo
         remote   = remotes.find { |r| r[:remote] == 'upstream' }
         remote ||= remotes.find { |r| r[:remote] == 'origin' }

--- a/lib/ghi/commands/command.rb
+++ b/lib/ghi/commands/command.rb
@@ -57,8 +57,13 @@ module GHI
 
       def require_repo
         return true if repo
-        warn 'Not a GitHub repo.'
-        warn ''
+        warn <<-WARNING
+Current directory is not a GitHub repository. Please retry this command from a
+directory that is also GitHub repository or by using the user/repo suffix:
+
+    #{$0} -- [<user>/]<repo>
+
+        WARNING
         abort options.to_s
       end
 
@@ -72,7 +77,7 @@ module GHI
         end
         return repo_name
       end
-        
+
       def detect_repo
         remote   = remotes.find { |r| r[:remote] == 'upstream' }
         remote ||= remotes.find { |r| r[:remote] == 'origin' }


### PR DESCRIPTION
In #279, a user expressed confusion that `[ -- [<user>/]<repo> ]` as a
command suffix is actually global and can be used with any command. This
patch adds a helpful message to the warning "Not a GitHub repo" to
suggest either re-running the command from a GitHub repo, or using the
suffix.

Fixes #279.

Signed-off-by: David Celis <me@davidcel.is>