### PR TITLE
Fix GitHub repo warning

### DIFF
--- a/ghi
+++ b/ghi
@@ -20,8 +20,11 @@ require 'optparse'
 
 module GHI
   class << self
+    attr_reader :current_command
+
     def execute args
       STDOUT.sync = true
+      @current_command = "#{$0} #{args.join(' ')}".freeze
 
       double_dash = args.index { |arg| arg == '--' }
       if index = args.index { |arg| arg !~ /^-/ }
@@ -1512,9 +1515,9 @@ module GHI
         return true if repo
         warn <<-WARNING
 Current directory is not a GitHub repository. Please retry this command from a
-directory that is also GitHub repository or by using the user/repo suffix:
+GitHub repository or by appending your command with the user/repo:
 
-    #{$0} -- [<user>/]<repo>
+    #{GHI.current_command} -- [<user>/]<repo>
 
         WARNING
         abort options.to_s

--- a/lib/ghi.rb
+++ b/lib/ghi.rb
@@ -9,8 +9,11 @@ module GHI
   autoload :Web,           'ghi/web'
 
   class << self
+    attr_reader :current_command
+
     def execute args
       STDOUT.sync = true
+      @current_command = "#{$0} #{args.join(' ')}".freeze
 
       double_dash = args.index { |arg| arg == '--' }
       if index = args.index { |arg| arg !~ /^-/ }

--- a/lib/ghi/commands/command.rb
+++ b/lib/ghi/commands/command.rb
@@ -59,9 +59,9 @@ module GHI
         return true if repo
         warn <<-WARNING
 Current directory is not a GitHub repository. Please retry this command from a
-directory that is also GitHub repository or by using the user/repo suffix:
+GitHub repository or by appending your command with the user/repo:
 
-    #{$0} -- [<user>/]<repo>
+    #{GHI.current_command} -- [<user>/]<repo>
 
         WARNING
         abort options.to_s


### PR DESCRIPTION
It turns out that either `$0` doesn't include `ARGV` like I thought it did, or that slicing `ARGV` up subsequently mutates `$0`. Either way, I've modified GHI to store the full command being run so that the warning printed when not in a GitHub repo is more accurate.

Signed-off-by: David Celis <me@davidcel.is>