### PR TITLE
Check if proxy_uri is nil before parsing

### DIFF
--- a/ghi
+++ b/ghi
@@ -1431,8 +1431,11 @@ module GHI
     def curl path = '', params = {}
       proxy_uri   = GHI.config 'https.proxy', :upcase => false
       proxy_uri ||= GHI.config 'http.proxy',  :upcase => false
-      proxy = URI.parse proxy_uri
-      if !(proxy.user.nil? || proxy.password.nil?)
+      proxy = nil
+      if proxy_uri
+        proxy = URI.parse proxy_uri
+      end
+      if proxy && proxy.user && proxy.password
         uri_for(path, params).open(:proxy_http_basic_authentication => [proxy_uri, proxy.user, proxy.password]).read
       else
         uri_for(path, params).open.read

--- a/lib/ghi/web.rb
+++ b/lib/ghi/web.rb
@@ -23,8 +23,11 @@ module GHI
     def curl path = '', params = {}
       proxy_uri   = GHI.config 'https.proxy', :upcase => false
       proxy_uri ||= GHI.config 'http.proxy',  :upcase => false
-      proxy = URI.parse proxy_uri
-      if !(proxy.user.nil? || proxy.password.nil?)
+      proxy = nil
+      if proxy_uri
+        proxy = URI.parse proxy_uri
+      end
+      if proxy && proxy.user && proxy.password
         uri_for(path, params).open(:proxy_http_basic_authentication => [proxy_uri, proxy.user, proxy.password]).read
       else
         uri_for(path, params).open.read


### PR DESCRIPTION
URI.parse is able to handle empty string("") as uri but not nil. Fixes #296