### PR TITLE
Handle case when repo is renamed but upstream url not updated

### DIFF
--- a/ghi
+++ b/ghi
@@ -1350,8 +1350,9 @@ module GHI
         if password.nil?
           raise Authorization::Required, 'Authorization required'
         end
-      when Net::HTTPMovedPermanently
-        return Response.new(http.get(res['location']))
+      when Net::HTTPMovedPermanently, Net::HTTPTemporaryRedirect
+        path = URI.parse(res['location']).path
+        return request method, path, options
       end
 
       raise Error, res

--- a/lib/ghi/client.rb
+++ b/lib/ghi/client.rb
@@ -138,8 +138,9 @@ module GHI
         if password.nil?
           raise Authorization::Required, 'Authorization required'
         end
-      when Net::HTTPMovedPermanently
-        return Response.new(http.get(res['location']))
+      when Net::HTTPMovedPermanently, Net::HTTPTemporaryRedirect
+        path = URI.parse(res['location']).path
+        return request method, path, options
       end
 
       raise Error, res


### PR DESCRIPTION
When repo is renamed and we use the old url for api call, the response
is Net::HTTPTemporaryRedirect and it contains the currosponding new url.

Fixes #267.
Before testing this, merge #298 because of #299 .
Or you can test this version which I merged
https://github.com/shubhamshuklaer/ghi/blob/repo_renaming_test/ghi