### PR TITLE
Take title and description on cmdline for milestone just like open

### DIFF
--- a/ghi
+++ b/ghi
@@ -2743,6 +2743,9 @@ EOF
           if web
             Web.new(repo).open 'issues/milestones/new'
           else
+            unless args.empty?
+              assigns[:title], assigns[:description] = args.join(' '), assigns[:title]
+            end
             if assigns[:title].nil?
               e = Editor.new 'GHI_MILESTONE.md'
               message = e.gets format_milestone_editor

--- a/lib/ghi/commands/milestone.rb
+++ b/lib/ghi/commands/milestone.rb
@@ -139,6 +139,9 @@ EOF
           if web
             Web.new(repo).open 'issues/milestones/new'
           else
+            unless args.empty?
+              assigns[:title], assigns[:description] = args.join(' '), assigns[:title]
+            end
             if assigns[:title].nil?
               e = Editor.new 'GHI_MILESTONE.md'
               message = e.gets format_milestone_editor


### PR DESCRIPTION
Now `ghi milestone sample_title -m sample_description` will create a
milestone with title as sample_title and description as
sample_description. Fixes #303 