### PR TITLE
Add `ghi lock` and `ghi unlock` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The most commonly used ghi commands are:
    show        Show an issue's details
    open        Open (or reopen) an issue
    close       Close an issue
+   lock        Lock an issue's conversation, limiting it to collaborators
+   unlock      Unlock an issue's conversation, opening it to all viewers
    edit        Modify an existing issue
    comment     Leave a comment on an issue
    label       Create, list, modify, or delete labels
@@ -47,7 +49,7 @@ See 'ghi help <command>' for more information on a specific command.
 ```
 
 ## Source Tree
-You may get a strange error if you use SourceTree, similar to [#275](https://github.com/stephencelis/ghi/issues/275) and [#189](https://github.com/stephencelis/ghi/issues/189). You can follow the steps [here](https://github.com/stephencelis/ghi/issues/275#issuecomment-182895962) to resolve this. 
+You may get a strange error if you use SourceTree, similar to [#275](https://github.com/stephencelis/ghi/issues/275) and [#189](https://github.com/stephencelis/ghi/issues/189). You can follow the steps [here](https://github.com/stephencelis/ghi/issues/275#issuecomment-182895962) to resolve this.
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,10 +21,12 @@ task :build do
     lib/ghi/commands/help.rb
     lib/ghi/commands/label.rb
     lib/ghi/commands/list.rb
+    lib/ghi/commands/lock.rb
     lib/ghi/commands/milestone.rb
     lib/ghi/commands/open.rb
     lib/ghi/commands/show.rb
     lib/ghi/commands/status.rb
+    lib/ghi/commands/unlock.rb
     bin/ghi
   )
   files = FileList[*manifest]

--- a/ghi
+++ b/ghi
@@ -746,6 +746,55 @@ module GHI
       }
     end
 
+    def extract_milestones_from_issues issues
+      return 'None.' if issues.empty?
+
+      nmax, rmax = %w(number repo).map { |f|
+        issues.sort_by { |i| i[f].to_s.size }.last[f].to_s.size
+      }
+
+      milestones = {}
+      extracted_milestones = []
+      milestone_index = 0
+      issues.map { |i|
+        milestone = i['milestone']
+        milestone["issues"] = [] if milestone && !(milestones.key? milestone["id"])
+        if milestone
+          if !milestones.key? milestone["id"]
+            milestones.merge!({milestone["id"] => milestone_index })
+            i.delete "milestone"
+            milestone["issues"] << i
+            extracted_milestones << milestone
+            milestone_index += 1
+          else
+            pos_of_existent_milestone = milestones[milestone["id"]]
+            i.delete "milestone"
+            extracted_milestones[pos_of_existent_milestone]["issues"] << i
+          end
+        end
+      }
+      extracted_milestones.sort! { |m1, m2| m1['number'] <=> m2['number'] }
+    end
+
+    def format_issues_by_milestone issues, include_repo
+      issues_by_milestone = extract_milestones_from_issues issues
+
+      nmax, rmax = %w(number repo).map { |f|
+        issues.sort_by { |i| i[f].to_s.size }.last[f].to_s.size
+      }
+
+      l = 9 + nmax + rmax
+
+      issues_by_milestone.map { |milestone|
+        title =  milestone['title'] if milestone["issues"]
+        [
+          ("\n  " if milestone["issues"]),
+          ("Milestone: " + fg(:green) { truncate(title,l) } if title),
+             (format_issues(milestone["issues"], include_repo))
+        ].compact
+      }
+    end
+
     def format_number n
       colorize? ? "#{bright { n }}:" : "#{n} "
     end
@@ -2169,6 +2218,8 @@ The most commonly used ghi commands are:
    show        Show an issue's details
    open        Open (or reopen) an issue
    close       Close an issue
+   lock        Lock an issue's conversation, limiting it to collaborators
+   unlock      Unlock an issue's conversation, opening it to all viewers
    edit        Modify an existing issue
    comment     Leave a comment on an issue
    label       Create, list, modify, or delete labels
@@ -2511,6 +2562,11 @@ module GHI
 	    assigns[:org] = org
             @repo = nil
           end
+            opts.on(
+              '--by-milestone', 'filter by milestone'
+            ) do
+              assigns[:by_m] = true
+            end
           opts.separator ''
         end
       end
@@ -2564,7 +2620,11 @@ module GHI
             if verbose
               puts issues.map { |i| format_issue i }
             else
-              puts format_issues(issues, repo.nil?)
+              if assigns[:by_m]
+                puts format_issues_by_milestone(issues, repo.nil?)
+              else
+                puts format_issues(issues, repo.nil?)
+              end
             end
             break unless res.next_page
             res = throb { api.get res.next_page }
@@ -2598,6 +2658,49 @@ module GHI
           opts.on('-c', '--closed') { assigns[:state] = 'closed' }
           opts.on('-q', '--quiet')  { self.quiet = true }
         end
+      end
+    end
+  end
+end
+module GHI
+  module Commands
+    class Lock < Command
+      def options
+        OptionParser.new do |opts|
+          opts.banner = <<EOF
+usage: ghi lock [options] <issueno>
+EOF
+          opts.separator ''
+          opts.separator 'Issue modification options'
+          opts.on '-m', '--message [<text>]', 'lock with message' do |text|
+            assigns[:comment] = text
+          end
+          opts.separator ''
+        end
+      end
+
+      def execute
+        options.parse! args
+        require_repo
+        require_issue
+
+        if assigns.key? :comment
+          Comment.execute [
+            issue, '-m', assigns[:comment], '--', repo
+          ].compact
+        end
+
+        throb { api.put "/repos/#{repo}/issues/#{issue}/lock" }
+
+        puts 'Locked.'
+      rescue Client::Error => e
+        raise unless error = e.errors.first
+        abort "%s %s %s %s." % [
+          error['resource'],
+          error['field'],
+          [*error['value']].join(', '),
+          error['code']
+        ]
       end
     end
   end
@@ -3003,6 +3106,49 @@ module GHI
           puts "Issues are not enabled for this repo"
         end
 
+      end
+    end
+  end
+end
+module GHI
+  module Commands
+    class Unlock < Command
+      def options
+        OptionParser.new do |opts|
+          opts.banner = <<EOF
+usage: ghi unlock [options] <issueno>
+EOF
+          opts.separator ''
+          opts.separator 'Issue modification options'
+          opts.on '-m', '--message [<text>]', 'unlock with message' do |text|
+            assigns[:comment] = text
+          end
+          opts.separator ''
+        end
+      end
+
+      def execute
+        options.parse! args
+        require_repo
+        require_issue
+
+        throb { api.delete "/repos/#{repo}/issues/#{issue}/lock" }
+
+        if assigns.key? :comment
+          Comment.execute [
+            issue, '-m', assigns[:comment], '--', repo
+          ].compact
+        end
+
+        puts 'Unlocked.'
+      rescue Client::Error => e
+        raise unless error = e.errors.first
+        abort "%s %s %s %s." % [
+          error['resource'],
+          error['field'],
+          [*error['value']].join(', '),
+          error['code']
+        ]
       end
     end
   end

--- a/lib/ghi/commands.rb
+++ b/lib/ghi/commands.rb
@@ -13,11 +13,13 @@ module GHI
 		autoload :Enable,    'ghi/commands/enable'
     autoload :Help,      'ghi/commands/help'
     autoload :Label,     'ghi/commands/label'
+    autoload :Lock,      'ghi/commands/lock'
     autoload :Milestone, 'ghi/commands/milestone'
     autoload :Reopen,    'ghi/commands/reopen'
     autoload :Show,      'ghi/commands/show'
 		autoload :Status,    'ghi/commands/status'
     autoload :Unassign,  'ghi/commands/unassign'
+    autoload :Unlock,    'ghi/commands/unlock'
     autoload :Version,   'ghi/commands/version'
   end
 end

--- a/lib/ghi/commands/help.rb
+++ b/lib/ghi/commands/help.rb
@@ -30,6 +30,8 @@ The most commonly used ghi commands are:
    show        Show an issue's details
    open        Open (or reopen) an issue
    close       Close an issue
+   lock        Lock an issue's conversation, limiting it to collaborators
+   unlock      Unlock an issue's conversation, opening it to all viewers
    edit        Modify an existing issue
    comment     Leave a comment on an issue
    label       Create, list, modify, or delete labels

--- a/lib/ghi/commands/lock.rb
+++ b/lib/ghi/commands/lock.rb
@@ -1,0 +1,43 @@
+module GHI
+  module Commands
+    class Lock < Command
+      def options
+        OptionParser.new do |opts|
+          opts.banner = <<EOF
+usage: ghi lock [options] <issueno>
+EOF
+          opts.separator ''
+          opts.separator 'Issue modification options'
+          opts.on '-m', '--message [<text>]', 'lock with message' do |text|
+            assigns[:comment] = text
+          end
+          opts.separator ''
+        end
+      end
+
+      def execute
+        options.parse! args
+        require_repo
+        require_issue
+
+        if assigns.key? :comment
+          Comment.execute [
+            issue, '-m', assigns[:comment], '--', repo
+          ].compact
+        end
+
+        throb { api.put "/repos/#{repo}/issues/#{issue}/lock" }
+
+        puts 'Locked.'
+      rescue Client::Error => e
+        raise unless error = e.errors.first
+        abort "%s %s %s %s." % [
+          error['resource'],
+          error['field'],
+          [*error['value']].join(', '),
+          error['code']
+        ]
+      end
+    end
+  end
+end

--- a/lib/ghi/commands/unlock.rb
+++ b/lib/ghi/commands/unlock.rb
@@ -1,0 +1,43 @@
+module GHI
+  module Commands
+    class Unlock < Command
+      def options
+        OptionParser.new do |opts|
+          opts.banner = <<EOF
+usage: ghi unlock [options] <issueno>
+EOF
+          opts.separator ''
+          opts.separator 'Issue modification options'
+          opts.on '-m', '--message [<text>]', 'unlock with message' do |text|
+            assigns[:comment] = text
+          end
+          opts.separator ''
+        end
+      end
+
+      def execute
+        options.parse! args
+        require_repo
+        require_issue
+
+        throb { api.delete "/repos/#{repo}/issues/#{issue}/lock" }
+
+        if assigns.key? :comment
+          Comment.execute [
+            issue, '-m', assigns[:comment], '--', repo
+          ].compact
+        end
+
+        puts 'Unlocked.'
+      rescue Client::Error => e
+        raise unless error = e.errors.first
+        abort "%s %s %s %s." % [
+          error['resource'],
+          error['field'],
+          [*error['value']].join(', '),
+          error['code']
+        ]
+      end
+    end
+  end
+end

--- a/man/ghi.1
+++ b/man/ghi.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GHI" "1" "April 2012" "Stephen Celis" "GHI Manual"
+.TH "GHI" "1" "June 2016" "Stephen Celis" "GHI Manual"
 .
 .SH "NAME"
 \fBghi\fR \- the stupid issue tracker
@@ -55,6 +55,14 @@ Assign an issue to yourself (or someone else)\.
 .TP
 \fBghi\-close\fR(1)
 Close an issue\.
+.
+.TP
+\fBghi\-lock\fR(1)
+Lock an issue\'s conversation, limiting it to collaborators\.
+.
+.TP
+\fBghi\-unlock\fR(1)
+Unlock an issue\'s conversation, opening it to all viewers\.
 .
 .TP
 \fBghi\-comment\fR(1)

--- a/man/ghi.1.html
+++ b/man/ghi.1.html
@@ -111,6 +111,8 @@ is named, this option will bring up the manual page for that command.</p>
 <dl>
 <dt><code>ghi-assign</code>(1)</dt><dd><p>Assign an issue to yourself (or someone else).</p></dd>
 <dt><code>ghi-close</code>(1)</dt><dd><p>Close an issue.</p></dd>
+<dt><code>ghi-lock</code>(1)</dt><dd><p>Lock an issue's conversation, limiting it to collaborators.</p></dd>
+<dt><code>ghi-unlock</code>(1)</dt><dd><p>Unlock an issue's conversation, opening it to all viewers.</p></dd>
 <dt><code>ghi-comment</code>(1)</dt><dd><p>Leave a comment on an issue.</p></dd>
 <dt><code>ghi-config</code>(1)</dt><dd><p>Configure GHI.</p></dd>
 <dt><code>ghi-edit</code>(1)</dt><dd><p>Modify an existing issue.</p></dd>
@@ -158,7 +160,7 @@ at <a href="https://github.com/stephencelis/ghi/contributors" data-bare-link="tr
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>Stephen Celis</li>
-    <li class='tc'>April 2012</li>
+    <li class='tc'>June 2016</li>
     <li class='tr'>ghi(1)</li>
   </ol>
 

--- a/man/ghi.1.ronn
+++ b/man/ghi.1.ronn
@@ -47,6 +47,12 @@ The <command> is either the name of a GHI command (see below) or an alias.
   * `ghi-close`(1):
     Close an issue.
 
+  * `ghi-lock`(1):
+    Lock an issue's conversation, limiting it to collaborators.
+
+  * `ghi-unlock`(1):
+    Unlock an issue's conversation, opening it to all viewers.
+
   * `ghi-comment`(1):
     Leave a comment on an issue.
 


### PR DESCRIPTION
A while back, I [added support for locking and unlocking issues via the API](https://developer.github.com/changes/2016-02-11-issue-locking-api/). This underwent a lengthy preview period that, as of today, [is over](https://developer.github.com/changes/2016-06-22-issue-locking-api-is-now-official/).

With the preview media type no longer required in the `Accept` header, I thought I'd go ahead and quickly add the commands `ghi lock` and `ghi unlock`. These are both fairly straightforward commands, though I did keep the `-m` option that's also present on `ghi close` to provide a comment before locking (or unlocking) the given issue.

Signed-off-by: David Celis <me@davidcel.is>