### PR TITLE
Make default issue-sorting method configurable

### DIFF
--- a/ghi
+++ b/ghi
@@ -704,7 +704,7 @@ module GHI
       if excluded_labels = assigns[:exclude_labels]
         header << ", excluding those labeled #{excluded_labels.gsub ',', ', '}"
       end
-      if sort = assigns[:sort]
+      if sort = assigns[:sort] || GHI.config('ghi.sort')
         header << ", by #{sort} #{reverse ? 'ascending' : 'descending'}"
       end
       format_state assigns[:state], header
@@ -2583,6 +2583,7 @@ module GHI
           fallback.parse! e.args
           retry
         end
+        assigns[:sort] ||= GHI.config('ghi.sort')
         assigns[:labels] = assigns[:labels].join ',' if assigns[:labels]
         if assigns[:exclude_labels]
           assigns[:exclude_labels] = assigns[:exclude_labels].join ','

--- a/lib/ghi/commands/list.rb
+++ b/lib/ghi/commands/list.rb
@@ -132,6 +132,7 @@ module GHI
           fallback.parse! e.args
           retry
         end
+        assigns[:sort] ||= GHI.config('ghi.sort')
         assigns[:labels] = assigns[:labels].join ',' if assigns[:labels]
         if assigns[:exclude_labels]
           assigns[:exclude_labels] = assigns[:exclude_labels].join ','

--- a/lib/ghi/formatting.rb
+++ b/lib/ghi/formatting.rb
@@ -161,7 +161,7 @@ module GHI
       if excluded_labels = assigns[:exclude_labels]
         header << ", excluding those labeled #{excluded_labels.gsub ',', ', '}"
       end
-      if sort = assigns[:sort]
+      if sort = assigns[:sort] || GHI.config('ghi.sort')
         header << ", by #{sort} #{reverse ? 'ascending' : 'descending'}"
       end
       format_state assigns[:state], header


### PR DESCRIPTION
This adds the `ghi.sort` option for the case where you want a different default sort method than `created`—e.g., you usually want `updated` instead. This change eliminates the need in that case to manually specify the `-S updated` option every single time you run `ghi list`. If you set the value of `ghi.sort` to `updated`, you can instead just type `ghi` and it will sort by `updated` instead.