### PR TITLE
Add a --verbose option for listing labels

### DIFF
--- a/lib/ghi/commands/label.rb
+++ b/lib/ghi/commands/label.rb
@@ -16,7 +16,7 @@ module GHI
 usage: ghi label <labelname> [-c <color>] [-r <newname>]
    or: ghi label -D <labelname>
    or: ghi label <issueno(s)> [-a] [-d] [-f] <label>
-   or: ghi label -l [<issueno>]
+   or: ghi label -l [<issueno>] [-v]
 EOF
           opts.separator ''
           opts.on '-l', '--list [<issueno>]', 'list label names' do |n|
@@ -37,6 +37,9 @@ EOF
           opts.on '-r', '--rename <labelname>', 'new label name' do |name|
             assigns[:name] = name
             self.action = 'update'
+          end
+          opts.on '-v', '--verbose', 'show color values for labels' do |v|
+            self.verbose = true
           end
           opts.separator ''
           opts.separator 'Issue modification options'
@@ -84,6 +87,9 @@ EOF
         else
           puts labels.map { |label|
             name = label['name']
+            if self.verbose
+              name += " ##{label['color']}"
+            end
             colorize? ? bg(label['color']) { " #{name} " } : name
           }
         end

--- a/lib/ghi/commands/label.rb
+++ b/lib/ghi/commands/label.rb
@@ -38,7 +38,7 @@ EOF
             assigns[:name] = name
             self.action = 'update'
           end
-          opts.on '-v', '--verbose', 'show color values for labels' do |v|
+          opts.on '-v', '--verbose', 'show color values for labels' do
             self.verbose = true
           end
           opts.separator ''


### PR DESCRIPTION
When --verbose (-v) is passed to the `ghi label -l -v` command, it
shows the hex codes for the colors of the labels instead of just using
the color on the background in the terminal.

This allows users to know what colors are already being used in case
they want to make a matching set of labels for their repository.