### PR TITLE
Add 'all' state and options

### DIFF
--- a/ghi
+++ b/ghi
@@ -2469,8 +2469,8 @@ module GHI
             @repo = nil
           end
           opts.on(
-            '-s', '--state <in>', %w(open closed),
-            {'o'=>'open', 'c'=>'closed'}, "'open' or 'closed'"
+            '-s', '--state <in>', %w(open closed all),
+            {'o'=>'open', 'c'=>'closed', 'a'=>'all'}, "'open', 'closed', 'all'"
           ) do |state|
             assigns[:state] = state
           end
@@ -2656,6 +2656,7 @@ module GHI
       def fallback
         OptionParser.new do |opts|
           opts.on('-c', '--closed') { assigns[:state] = 'closed' }
+          opts.on('-a', '--all') { assigns[:state] = 'all' }
           opts.on('-q', '--quiet')  { self.quiet = true }
         end
       end

--- a/lib/ghi/commands/list.rb
+++ b/lib/ghi/commands/list.rb
@@ -18,8 +18,8 @@ module GHI
             @repo = nil
           end
           opts.on(
-            '-s', '--state <in>', %w(open closed),
-            {'o'=>'open', 'c'=>'closed'}, "'open' or 'closed'"
+            '-s', '--state <in>', %w(open closed all),
+            {'o'=>'open', 'c'=>'closed', 'a'=>'all'}, "'open', 'closed', 'all'"
           ) do |state|
             assigns[:state] = state
           end
@@ -205,6 +205,7 @@ module GHI
       def fallback
         OptionParser.new do |opts|
           opts.on('-c', '--closed') { assigns[:state] = 'closed' }
+          opts.on('-a', '--all') { assigns[:state] = 'all' }
           opts.on('-q', '--quiet')  { self.quiet = true }
         end
       end


### PR DESCRIPTION
Here is a small change to support viewing open and closed issues.

Tested in a separate repo, test results:

``` bash
psypete@windows:~/git/devopsyoga-content-local/edit-ghi (gh-pages)$ ~/git/ghi/ghi list      
# peterwwillis/devopsyoga-content open issues
  1: Test issue: open  test 
psypete@windows:~/git/devopsyoga-content-local/edit-ghi (gh-pages)$ ~/git/ghi/ghi list -s closed
# peterwwillis/devopsyoga-content closed issues
  2: Test issue: closed  test  1
psypete@windows:~/git/devopsyoga-content-local/edit-ghi (gh-pages)$ ~/git/ghi/ghi list --all
# peterwwillis/devopsyoga-content all issues
  2: Test issue: closed  test  1
  1: Test issue: open  test 
psypete@windows:~/git/devopsyoga-content-local/edit-ghi (gh-pages)$ ~/git/ghi/ghi list -s all
# peterwwillis/devopsyoga-content all issues
  2: Test issue: closed  test  1
  1: Test issue: open  test 
```