### PR TITLE
Remove URI.escape obsolete method calling

### DIFF
--- a/ghi
+++ b/ghi
@@ -1358,7 +1358,6 @@ module GHI
     def request method, path, options
       path = "/api/v3#{path}" if HOST != DEFAULT_HOST
 
-      path = URI.escape path
       if params = options[:params] and !params.empty?
         q = params.map { |k, v| "#{CGI.escape k.to_s}=#{CGI.escape v.to_s}" }
         path += "?#{q.join '&'}"

--- a/lib/ghi/client.rb
+++ b/lib/ghi/client.rb
@@ -97,7 +97,6 @@ module GHI
     def request method, path, options
       path = "/api/v3#{path}" if HOST != DEFAULT_HOST
 
-      path = URI.escape path
       if params = options[:params] and !params.empty?
         q = params.map { |k, v| "#{CGI.escape k.to_s}=#{CGI.escape v.to_s}" }
         path += "?#{q.join '&'}"


### PR DESCRIPTION
That obsolete method calling is useless.