### PR TITLE
fix URI.escape is obsolete #383

### DIFF
--- a/ghi
+++ b/ghi
@@ -1358,7 +1358,8 @@ module GHI
     def request method, path, options
       path = "/api/v3#{path}" if HOST != DEFAULT_HOST
 
-      path = URI.escape path
+      parser = URI::Parser.new
+      path = parser.escape(path)
       if params = options[:params] and !params.empty?
         q = params.map { |k, v| "#{CGI.escape k.to_s}=#{CGI.escape v.to_s}" }
         path += "?#{q.join '&'}"

--- a/lib/ghi/client.rb
+++ b/lib/ghi/client.rb
@@ -97,7 +97,8 @@ module GHI
     def request method, path, options
       path = "/api/v3#{path}" if HOST != DEFAULT_HOST
 
-      path = URI.escape path
+      parser = URI::Parser.new
+      path = parser.escape(path)
       if params = options[:params] and !params.empty?
         q = params.map { |k, v| "#{CGI.escape k.to_s}=#{CGI.escape v.to_s}" }
         path += "?#{q.join '&'}"


### PR DESCRIPTION
This removes the `/usr/local/Cellar/ghi/1.2.0_4/libexec/bin/ghi:1305: warning: URI.escape is obsolete` warning, applying the solution proposed by https://stackoverflow.com/a/67618304/890242

