### PR TITLE
Removed URI.escape warning with ruby 3+ - fixes #391

### DIFF
--- a/lib/ghi/client.rb
+++ b/lib/ghi/client.rb
@@ -97,7 +97,9 @@ module GHI
     def request method, path, options
       path = "/api/v3#{path}" if HOST != DEFAULT_HOST
 
-      path = URI.escape path
+      # path = URI.escape path # obsolete in ruby 3.0
+      p = URI::Parser.new
+      path = p.escape(path)
       if params = options[:params] and !params.empty?
         q = params.map { |k, v| "#{CGI.escape k.to_s}=#{CGI.escape v.to_s}" }
         path += "?#{q.join '&'}"


### PR DESCRIPTION
Just a small fix to remove the annoying warning... There seem to be several solutions but this one seems to be a 1:1 replacement of URI.escape - from https://stackoverflow.com/questions/65423458/ruby-2-7-says-uri-escape-is-obsolete-what-replaces-it